### PR TITLE
Linking entity listing display to badge settings path.

### DIFF
--- a/user_badges.links.action.yml
+++ b/user_badges.links.action.yml
@@ -9,4 +9,4 @@ entity.badge_type.add_form:
   route_name: 'entity.badge_type.add_form'
   title: 'Add Badge type'
   appears_on:
-    - entity.badge_type.collection
+    - badge.settings

--- a/user_badges.links.menu.yml
+++ b/user_badges.links.menu.yml
@@ -11,11 +11,5 @@ badge.admin.structure.settings:
   description: 'Configure Badge entities'
   route_name: badge.settings
   parent: system.admin_structure
-# Badge type menu items definition
-entity.badge_type.collection:
-  title: 'Badge type'
-  route_name: entity.badge_type.collection
-  description: 'List Badge type (bundles)'
-  parent: system.admin_structure
-  weight: 99
+
 

--- a/user_badges.routing.yml
+++ b/user_badges.routing.yml
@@ -40,17 +40,6 @@ entity.badge.delete_form:
   options:
     _admin_route: TRUE
 
-
-entity.badge_type.collection:
-  path: 'admin/badge_types/list'
-  defaults:
-    _entity_list: 'badge_type'
-    _title: 'badge_type list'
-  requirements:
-    _permission: 'view badge type entities'
-  options:
-    _admin_route: TRUE
-
 entity.badge_type.add_form:
   path: '/admin/structure/badge_type/add'
   defaults:
@@ -84,10 +73,10 @@ entity.badge_type.delete_form:
 badge.settings:
   path: 'admin/structure/badge'
   defaults:
-   _form: '\Drupal\user_badges\Entity\Form\BadgeSettingsForm'
-   _title: 'Badge settings'
+    _entity_list: 'badge_type'
+    _title: 'Badge settings'
   requirements:
-    _permission: 'administer badge entities'
+    _permission: 'view badge type entities'
   options:
     _admin_route: TRUE
 


### PR DESCRIPTION
Removing existing badge_type listing path as it is not required now.
